### PR TITLE
Dialog 1.9.1

### DIFF
--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1796</string>
+	<string>1798</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1946</string>
+	<string>1949</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1935</string>
+	<string>1946</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1798</string>
+	<string>1833</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1934</string>
+	<string>1935</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1785</string>
+	<string>1796</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -12,35 +12,14 @@ import Combine
 
 struct DropdownView: View {
     
-    @State var selectedOption = cloptions.dropdownDefault.value // CLOptionText(OptionName: cloptions.dropdownDefault)
-    //@Binding var selectedOption: String = CLOptionText(OptionName: cloptions.dropdownDefault, DefaultValue: "")
-    var selectedIndex = -1
-    var dropdownValues = [""]
-    var dropdownCLValues: String = ""
-    var dropdownTitle: String = ""
-    
-    var showDropdown: Bool = false
+    @State var selectedOption = cloptions.dropdownDefault.value
+
+    var dropdownValues = appvars.dropdownValuesArray
+    var dropdownTitle: String = cloptions.dropdownTitle.value
+    var showDropdown: Bool = cloptions.dropdownValues.present
     var defaultValue: String = ""
     
-    init() {
-        if cloptions.dropdownValues.present {
-            showDropdown = true
-            dropdownCLValues = cloptions.dropdownValues.value
-            dropdownValues = dropdownCLValues.components(separatedBy: ",")
-            dropdownValues = dropdownValues.map { $0.trimmingCharacters(in: .whitespaces) } // trim out any whitespace from the values if there were spaces before after the comma
-            dropdownTitle = cloptions.dropdownTitle.value
-        }
-        if cloptions.dropdownDefault.present && cloptions.dropdownValues.value.contains(cloptions.dropdownDefault.value) {
-            appvars.selectedOption = selectedOption
-            appvars.selectedIndex = dropdownValues.firstIndex {$0 == selectedOption} ?? -1
-            //appvars.selectedIndex += 1
-        }
-    }
-    
-    func updateSelectedOption() {
-        appvars.selectedOption = self.selectedOption
-    }
-    
+        
     var body: some View {
         if showDropdown {
             HStack {
@@ -61,15 +40,12 @@ struct DropdownView: View {
                 .pickerStyle(DefaultPickerStyle())
                 .frame(maxWidth: 450, alignment: .trailing)
                 .onChange(of: selectedOption) { _ in
-                            //update appvars with the option that was selected. this will be printed to stdout on exit
-                            appvars.selectedOption = selectedOption
-                            appvars.selectedIndex = dropdownValues.firstIndex {$0 == selectedOption} ?? -1
-                            //appvars.selectedIndex += 1  // removed by popular opinion
-                        }
+                    //update appvars with the option that was selected. this will be printed to stdout on exit
+                    appvars.selectedOption = selectedOption
+                    appvars.selectedIndex = dropdownValues.firstIndex {$0 == selectedOption} ?? -1
+                }
             }
             .frame(maxWidth: 500)
         }
     }
-    
-    
 }

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -46,7 +46,7 @@ struct DropdownView: View {
             HStack {
                 // we could print the title as part of the picker control but then we don't get easy access to swiftui text formatting
                 // so we print it seperatly and use a blank value in the picker
-                //Spacer()
+                Spacer()
                 Text(dropdownTitle)
                     .bold()
                     .font(.system(size: 15))
@@ -59,7 +59,7 @@ struct DropdownView: View {
                     }
                 }
                 .pickerStyle(DefaultPickerStyle())
-                .frame(width: appvars.windowWidth*0.45, alignment: .trailing)
+                .frame(maxWidth: 450, alignment: .trailing)
                 .onChange(of: selectedOption) { _ in
                             //update appvars with the option that was selected. this will be printed to stdout on exit
                             appvars.selectedOption = selectedOption
@@ -67,6 +67,7 @@ struct DropdownView: View {
                             //appvars.selectedIndex += 1  // removed by popular opinion
                         }
             }
+            .frame(maxWidth: 500)
         }
     }
     

--- a/dialog/UI/IconOverlayView.swift
+++ b/dialog/UI/IconOverlayView.swift
@@ -61,7 +61,11 @@ struct IconOverlayView: View {
                     builtInIconWeight = textToFontWeight(item[1])
                 }
                 if itemName.hasPrefix("bgcolour") || itemName.hasPrefix("bgcolor") {
-                    sfBackgroundIconColour = stringToColour(itemValue)
+                    if itemValue == "none" {
+                        sfBackgroundIconColour = .clear
+                    } else {
+                        sfBackgroundIconColour = stringToColour(itemValue)
+                    }
                 }
                 if itemName.hasPrefix("colour") || itemName.hasPrefix("color") {
                     if itemValue == "auto" {

--- a/dialog/UI/MessageContentView.swift
+++ b/dialog/UI/MessageContentView.swift
@@ -60,16 +60,20 @@ struct MessageContent: View {
                 .border(appvars.debugBorderColour, width: 2)
                                 
                 Spacer()
-            
-                TextEntryView()
-                    .padding(.leading, 50)
-                    .padding(.trailing, 50)
-                    .border(appvars.debugBorderColour, width: 2)
-                                
-                DropdownView()
-                    .padding(.leading, 50)
-                    .padding(.trailing, 50)
-                    .border(appvars.debugBorderColour, width: 2)
+                HStack() {
+                    Spacer()
+                    VStack {
+                        TextEntryView()
+                            .padding(.leading, 50)
+                            .padding(.trailing, 50)
+                            .border(appvars.debugBorderColour, width: 2)
+
+                        DropdownView()
+                            .padding(.leading, 50)
+                            .padding(.trailing, 50)
+                            .border(appvars.debugBorderColour, width: 2)
+                    }
+                }
             }
             .padding(.leading, 40)
             .padding(.trailing, 40)

--- a/dialog/UI/TextEntryView.swift
+++ b/dialog/UI/TextEntryView.swift
@@ -30,21 +30,21 @@ struct TextEntryView: View {
             VStack {
                 ForEach(0..<textFieldLabels.count, id: \.self) {i in
                     HStack {
-                        //Spacer()
+                        Spacer()
                         Text(textFieldLabels[i])
                             .bold()
                             .font(.system(size: 15))
                             .frame(alignment: .leading)
                         Spacer()
                         TextField("", text: $textFieldValue[i])
-                            .frame(width: appvars.windowWidth*0.40, alignment: .trailing)
+                            .frame(maxWidth: 450, alignment: .trailing)
                             .onChange(of: textFieldValue[i], perform: { value in
                                 //update appvars with the text that was entered. this will be printed to stdout on exit
                                 appvars.textFieldText[i] = textFieldValue[i]
                             })
                     }
                 }
-            }
+            }.frame(maxWidth: 500)
         }
     }
 }

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -82,6 +82,7 @@ struct AppVariables {
     
     var selectedOption                  = ""
     var selectedIndex                   = 0
+    var dropdownValuesArray             = [String]()
 
     var jsonOut                         = Bool(false)
     

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -169,6 +169,7 @@ struct CLOptions {
     var statusLogFile            = (long: String("commandfile"),       short: String(""),    value : String(""), present : Bool(false))
 
     // command line options that take no additional parameters
+    var button1Disabled          = (long: String("button1disabled"),   short: String(""),    value : String(""), present : Bool(false))
     var button2Option            = (long: String("button2"),           short: String("2"),   value : String(""), present : Bool(false)) // -2
     var infoButtonOption         = (long: String("infobutton"),        short: String("3"),   value : String(""), present : Bool(false)) // -3
     var getVersion               = (long: String("version"),           short: String("v"),   value : String(""), present : Bool(false)) // -v

--- a/dialog/extras/ProcessCLOptions.swift
+++ b/dialog/extras/ProcessCLOptions.swift
@@ -57,8 +57,27 @@ func getJSON() -> JSON {
 
 func processCLOptions() {
     
+    //this method goes through the arguments that are present and performs any processing required before use
+    
     let json : JSON = getJSON()
-        
+    
+    if cloptions.dropdownValues.present {
+        if json[cloptions.dropdownValues.long].exists() {
+            appvars.dropdownValuesArray = json[cloptions.dropdownValues.long].arrayValue.map {$0.stringValue}
+        } else {
+    
+            let dropdownValues = cloptions.dropdownValues.value.components(separatedBy: ",")
+            appvars.dropdownValuesArray = dropdownValues.map { $0.trimmingCharacters(in: .whitespaces) } // trim out any whitespace from the values if there were spaces before after the comma
+        }
+    
+        if json[cloptions.dropdownDefault.long].exists() || cloptions.dropdownDefault.present {
+            appvars.selectedOption = cloptions.dropdownDefault.value
+            appvars.selectedIndex = appvars.dropdownValuesArray.firstIndex {$0 == cloptions.dropdownDefault.value} ?? -1
+        }
+    
+    }
+    
+    
     if cloptions.textField.present {
         if json[cloptions.textField.long].exists() {
             appvars.textOptionsArray = json[cloptions.textField.long].arrayValue.map {$0.stringValue}
@@ -295,6 +314,9 @@ func processCLOptions() {
 }
 
 func processCLOptionValues() {
+    
+    // this method reads in arguments from either json file or from the command line and loads them into the cloptions object
+    // also records whether an argument is present or not
     
     let json : JSON = getJSON()
     

--- a/dialog/extras/ProcessCLOptions.swift
+++ b/dialog/extras/ProcessCLOptions.swift
@@ -370,6 +370,8 @@ func processCLOptionValues() {
 
     cloptions.button1ShellActionOption.value = json[cloptions.button1ShellActionOption.long].string ?? CLOptionText(OptionName: cloptions.button1ShellActionOption)
     cloptions.button1ShellActionOption.present = json[cloptions.button1ShellActionOption.long].exists() || CLOptionPresent(OptionName: cloptions.button1ShellActionOption)
+    
+    cloptions.button1Disabled.present       = json[cloptions.button1Disabled.long].exists() || CLOptionPresent(OptionName: cloptions.button1Disabled)
 
     cloptions.button2TextOption.value       = json[cloptions.button2TextOption.long].string ?? CLOptionText(OptionName: cloptions.button2TextOption, DefaultValue: appvars.button2Default)
     cloptions.button2TextOption.present     = json[cloptions.button2TextOption.long].exists() || CLOptionPresent(OptionName: cloptions.button2TextOption)

--- a/dialog/extras/TrackProgress.swift
+++ b/dialog/extras/TrackProgress.swift
@@ -55,7 +55,7 @@ class DialogUpdatableContent : ObservableObject {
         progressValue = 0
         progressTotal = 0
         button1Value = cloptions.button1TextOption.value
-        button1Disabled = false
+        button1Disabled = cloptions.button1Disabled.present
         button2Value = cloptions.button2TextOption.value
         infoButtonValue = cloptions.infoButtonOption.value
         

--- a/dialog/extras/TrackProgress.swift
+++ b/dialog/extras/TrackProgress.swift
@@ -162,7 +162,7 @@ class DialogUpdatableContent : ObservableObject {
                 switch incrementValue {
                 case "increment" :
                     if progressTotal == 0 {
-                        progressTotal = 100
+                        progressTotal = Double(cloptions.progressBar.value) ?? 100
                     }
                     progressValue = progressValue + 1
                 case "reset" :
@@ -176,7 +176,7 @@ class DialogUpdatableContent : ObservableObject {
                 //    progressValue = 0
                 default :
                     if progressTotal == 0 {
-                        progressTotal = 100
+                        progressTotal = Double(cloptions.progressBar.value) ?? 100
                     }
                     progressValue = Double(incrementValue) ?? 0
                 }

--- a/dialog/extras/helpText.swift
+++ b/dialog/extras/helpText.swift
@@ -166,6 +166,10 @@ var helpText = """
                     Runs the specified shell command using zsh
                     Command input and output is not sanitised or checked.
                     If your command fails, Dialog still exits 0
+    
+        --\(cloptions.button1Disabled.long)
+                    Launches dialig with button1 disabled
+                    To re-enable, send `buton1: enable` to the dialog command file.
 
         -\(cloptions.button2Option.short), --\(cloptions.button2Option.long)
                     Displays button2 with default label of "\(appvars.button2Default)"

--- a/dialog/extras/jamfHelper.swift
+++ b/dialog/extras/jamfHelper.swift
@@ -79,6 +79,11 @@ public func convertFromJamfHelperSyntax() {
         appvars.iconIsHidden = true
     }
     
+    //icon size
+    cloptions.iconSize.present = CLOptionPresent(OptionName: JHOptions.iconSize)
+    cloptions.iconSize.value = CLOptionText(OptionName: JHOptions.iconSize)
+
+    
     //button 1
     cloptions.button1TextOption.present = CLOptionPresent(OptionName: JHOptions.button1)
     cloptions.button1TextOption.value = CLOptionText(OptionName: JHOptions.button1)


### PR DESCRIPTION
 - enhancement to options that can be modified by command file:
   - added `--listitem` [more details in the wiki](https://github.com/bartreardon/Dialog/wiki/Item-Lists)
 - added `iconsize` as one of the supported jamfhelper options
 - cleaned up `selectvalues` when using json as an input source. json will look like:
```json
{
  "selecttitle" : "Title Here",
  "selectvalues" : ["Select 1", "Select 2", "Select 3"],
  "selectdefault" : "Select 3"
}
```
 - fixed an issue with setting the number of progress increments as a command line argument. Was always defaulting to `100`